### PR TITLE
chore: add major version tagger github action

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -1,0 +1,13 @@
+name: Keep the versions up-to-date
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  actions-tagger:
+    runs-on: windows-latest
+    steps:
+      - uses: Actions-R-Us/actions-tagger@latest
+        env:
+          GITHUB_TOKEN: '${{secrets.GITHUB_TOKEN}}'


### PR DESCRIPTION
Helper to follow github actions versioning guideline according to
https://github.com/actions/toolkit/blob/master/docs/action-versioning.md#versioning