### PR TITLE
dep: rely on implicit dependencies from ansible-later

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,3 @@
 ansible==5.1.0
 ansible-later==0.5.14
-Jinja2==3.0.3
-jsonschema==3.2.0
 PyYAML==5.4.1
-yamllint==1.26.3


### PR DESCRIPTION
# Motivation

Some automated dependencies can not update due to version pinning. Rely on implicit versions of `ansible-later` instead